### PR TITLE
fix: unit test failed, pulling the wrong version of go

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,9 +10,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-env:
-  GO_VER: 1.20
-
 jobs:
   make-checks:
     runs-on: ubuntu-22.04
@@ -21,6 +18,6 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VER }}
+          go-version-file: "go.mod"
       - name: run tests
         run: make test


### PR DESCRIPTION
fix: unit test failed, pulling the wrong version of go