### PR TITLE
chore: use setup-go@v3 to support go-version-file

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
       - name: Run coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # bc-cli
+
+[![codecov](https://codecov.io/gh/bestchains/bc-cli/branch/main/graph/badge.svg?token=1KY5R58MRJ)](https://codecov.io/gh/bestchains/bc-cli)
+
 Command line tools for Bestchains


### PR DESCRIPTION
Fix: https://github.com/bestchains/bc-cli/pull/9#discussion_r1179854036