### PR TITLE
chore: tiny changes on bc-cli to make arguments much better

### DIFF
--- a/pkg/account/create.go
+++ b/pkg/account/create.go
@@ -40,9 +40,6 @@ func NewCreateAccountCmd(option common.Options) *cobra.Command {
 		Use:   "account",
 		Short: "Create an account",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if walletDir == "" {
-				walletDir = common.WalletConfigDir
-			}
 			walletDir = strings.TrimSuffix(walletDir, "/")
 			_, err := os.Stat(walletDir)
 			if err != nil {
@@ -113,6 +110,6 @@ func NewCreateAccountCmd(option common.Options) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&pkFile, "pk", "", "the user's own private key, which is automatically generated if not provided")
-	cmd.Flags().StringVar(&walletDir, "wallet", "", "wallet path")
+	cmd.Flags().StringVar(&walletDir, "wallet", common.DefaultWalletConfigDir, "wallet path")
 	return cmd
 }

--- a/pkg/account/delete.go
+++ b/pkg/account/delete.go
@@ -31,9 +31,6 @@ func NewDeleteAccountCmd(option common.Options) *cobra.Command {
 		Use:   "account [address]",
 		Short: "Delete the account according to the wallet information.",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			if walletDir == "" {
-				walletDir = common.WalletConfigDir
-			}
 			walletDir = strings.TrimSuffix(walletDir, "/")
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -52,6 +49,6 @@ func NewDeleteAccountCmd(option common.Options) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&walletDir, "wallet", "", "wallet path")
+	cmd.Flags().StringVar(&walletDir, "wallet", common.DefaultWalletConfigDir, "wallet path")
 	return cmd
 }

--- a/pkg/account/get.go
+++ b/pkg/account/get.go
@@ -35,9 +35,6 @@ func NewGetAccountCmd(option common.Options) *cobra.Command {
 		Use:   "account",
 		Short: "Display account information according to wallet path",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			if walletDir == "" {
-				walletDir = common.WalletConfigDir
-			}
 			walletDir = strings.TrimSuffix(walletDir, "/")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -64,6 +61,6 @@ func NewGetAccountCmd(option common.Options) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&walletDir, "wallet", "", "wallet path")
+	cmd.Flags().StringVar(&walletDir, "wallet", common.DefaultWalletConfigDir, "wallet path")
 	return cmd
 }

--- a/pkg/account/get_test.go
+++ b/pkg/account/get_test.go
@@ -45,7 +45,7 @@ func TestNewGetAccountCmd(t *testing.T) {
 	bufOutput := bytes.NewBuffer([]byte{})
 	bufErrOutput := bytes.NewBuffer([]byte{})
 	getCmd := NewGetAccountCmd(common.Options{IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: bufOutput, ErrOut: bufErrOutput}})
-	expectOutput := []string{fmt.Sprintf("Error: stat %s: no such file or directory\nError: stat /tmp/def/abc: no such file or directory\n", common.WalletConfigDir)}
+	expectOutput := []string{fmt.Sprintf("Error: stat %s: no such file or directory\nError: stat /tmp/def/abc: no such file or directory\n", common.DefaultWalletConfigDir)}
 
 	dirEntries, err := os.ReadDir(getTestPath)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestNewGetAccountCmd(t *testing.T) {
 	output := make([]string, 0)
 	// step 1: Use the default path and the default path does not exist
 	if err := getCmd.Execute(); err != nil {
-		t.Fatalf("run get account cmd with default wallet %s error %s", common.WalletConfigDir, err)
+		t.Fatalf("run get account cmd with default wallet %s error %s", common.DefaultWalletConfigDir, err)
 	}
 	// step 2: Using non-existent paths to obtain account information
 	_ = getCmd.Flags().Set("wallet", "/tmp/def/abc")

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	WalletConfigDir = filepath.Join(os.Getenv("HOME"), WalletHomeDir)
+	DefaultWalletConfigDir = filepath.Join(os.Getenv("HOME"), WalletHomeDir)
 )
 
 type WalletConfig struct {


### PR DESCRIPTION
Change logs:
1. Set default wallet dir when define command flag
2. As `--account` is good for us to make the choice on `trust` or `untrust`, we can remove `--untrust` flag 