### PR TITLE
feat: add gorelease to release binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+      # More assembly might be required: Docker logins, GPG, etc. It all depends
+      # on your needs.
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
+          # distribution:
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,5 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,218 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+#before:
+#  hooks:
+#    # You may remove this if you don't use go modules.
+#    - go mod tidy
+#    # you may remove this if you don't need go generate
+#    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/bc-cli/
+    ldflags:
+      - -s -w -X k8s.io/component-base/version.gitVersion={{.Version}} -X k8s.io/component-base/version.gitCommit={{.Commit}} -X k8s.io/component-base/version.buildDate={{.Date}}
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  sort: asc
+  # Changelog generation implementation to use.
+  #
+  # Valid options are:
+  # - `git`: uses `git log`;
+  # - `github`: uses the compare GitHub API, appending the author login to the changelog.
+  # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
+  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  #
+  # Default: 'git'
+  use: github
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Providing no regex means all commits will be grouped under the default group.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  # Matches are performed against strings of the form: "<abbrev-commit>[:] <title-commit>".
+  # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
+  groups:
+    - title: New Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    # Commit messages matching the regexp listed here will be removed from
+    # the changelog
+    exclude:
+      - '^Merge pull request'
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  #  github:
+  #    owner: user
+  #    name: repo
+
+  # IDs of the archives to use.
+  # Empty means all IDs.
+  #
+  # Default: []
+  #  ids:
+  #    - foo
+  #    - bar
+
+  # If set to true, will not auto-publish the release.
+  # Available only for GitHub and Gitea.
+  #
+  # Default: false
+  draft: true
+
+  # Whether to remove existing draft releases with the same name before creating
+  # a new one.
+  # Only effective if `draft` is set to true.
+  # Available only for GitHub.
+  #
+  # Default: false
+  # Since: v1.11
+  replace_existing_draft: false
+
+  # Useful if you want to delay the creation of the tag in the remote.
+  # You can create the tag locally, but not push it, and run GoReleaser.
+  # It'll then set the `target_commitish` portion of the GitHub release to the
+  # value of this field.
+  # Only works on GitHub.
+  #
+  # Default: ''
+  # Since: v1.11
+  # Templates: allowed
+  #  target_commitish: '{{ .Commit }}'
+
+  # This allows to change which tag GitHub will create.
+  # Usually you'll use this together with `target_commitish`, or if you want to
+  # publish a binary from a monorepo into a public repository somewhere, without
+  # the tag prefix.
+  #
+  # Default: '{{ .PrefixedCurrentTag }}'
+  # Since: v1.19 (pro)
+  # Templates: allowed
+  #  tag: '{{ .CurrentTag }}'
+
+  # If set, will create a release discussion in the category specified.
+  #
+  # Warning: do not use categories in the 'Announcement' format.
+  #  Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
+  #
+  # Default is empty.
+  #  discussion_category_name: General
+
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  #  prerelease: auto
+
+  # What to do with the release notes in case there the release already exists.
+  #
+  # Valid options are:
+  # - `keep-existing`: keep the existing notes
+  # - `append`: append the current release notes to the existing notes
+  # - `prepend`: prepend the current release notes to the existing notes
+  # - `replace`: replace existing notes
+  #
+  # Default is `keep-existing`.
+  mode: append
+
+  # Header for the release body.
+  #
+  # Templates: allowed
+  header: |
+    ## {{.ProjectName}}-v{{.Version}}
+
+    Welcome to this new release!
+    
+    ### Breaking Changes:
+    None
+    
+    ### Feature summary 🚀 🚀 🚀
+
+  # Footer for the release body.
+  #
+  # Templates: allowed
+  footer: |
+    ## Thanks to our Contributors!
+    
+    Thank you to everyone who contributed to {{.Tag}}! ❤️
+
+    And thank you very much to everyone else not listed here who contributed in other ways like filing issues, giving feedback, testing fixes, helping users in slack, etc. 🙏
+  # You can change the name of the release.
+  #
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+  # Templates: allowed
+  name_template: "v{{.Version}}"
+
+  # You can disable this pipe in order to not create the release on any SCM.
+  # Keep in mind that this might also break things that depend on the release
+  # URL, for instance, homebrew taps.
+  #
+  # Templates: allowed (since v1.15)
+  #  disable: true
+
+  # Set this to true if you want to disable just the artifact upload to the SCM.
+  # If this is true, GoReleaser will still create the release with the
+  # changelog, but won't upload anything to it.
+  #
+  # Since: v1.11
+  # Templates: allowed (since v1.15)
+  #  skip_upload: true
+
+  # You can add extra pre-existing files to the release.
+  # The filename on the release will be the last part of the path (base).
+  # If another file with the same name exists, the last one found will be used.
+  #
+  # Templates: allowed
+  #  extra_files:
+  #    - glob: ./path/to/file.txt
+  #    - glob: ./glob/**/to/**/file/**/*
+  #    - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+  #    - glob: ./single_file.txt
+  #      name_template: file.txt # note that this only works if glob matches 1 file only
+
+
+  # Additional templated extra files to add to the release.
+  # Those files will have their contents pass through the template engine,
+  # and its results will be added to the release.
+  #
+  # Since: v1.17 (pro)
+  # This feature is only available in GoReleaser Pro.
+  # Templates: allowed
+#  templated_extra_files:
+#    - src: LICENSE.tpl
+#      dst: LICENSE.txt
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/cmd/bc-cli/main.go
+++ b/cmd/bc-cli/main.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	goflags "flag"
+	"fmt"
+	"os"
 	"path"
 
 	"github.com/bestchains/bc-cli/cmd/bc-cli/create"
@@ -29,6 +31,7 @@ import (
 	"github.com/bestchains/bc-cli/pkg/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 )
 
@@ -94,6 +97,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(create.NewCreateCmd())
 	cmd.AddCommand(get.NewGetCmd())
 	cmd.AddCommand(delcmd.NewDeleteCmd())
+	cmd.AddCommand(newCmdVersion())
 	return cmd
 }
 
@@ -121,4 +125,20 @@ func loadConfig(configFile string) (config *common.Config, err error) {
 	}
 	klog.V(3).Infof("all config: %+v", config)
 	return config, nil
+}
+
+// newCmdVersion provides the version information of bc-cli
+func newCmdVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of bc-cli",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("version: %s\n", version.Get())
+			fmt.Printf("commit: %s\n", version.Get().GitCommit)
+			fmt.Printf("date: %s\n", version.Get().BuildDate)
+			os.Exit(0)
+		},
+		Args: cobra.NoArgs,
+	}
+	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/golangci/golangci-lint v1.52.2
 	github.com/int128/oauth2cli v1.14.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.12.0
+	github.com/stretchr/testify v1.8.2
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -17,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.27.1
 	k8s.io/cli-runtime v0.27.1
 	k8s.io/client-go v0.27.1
+	k8s.io/component-base v0.27.1
 	k8s.io/klog/v2 v2.90.1
 	k8s.io/kubectl v0.27.1
 )
@@ -168,7 +171,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.4.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
@@ -201,7 +203,6 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
@@ -242,7 +243,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.4.3 // indirect
-	k8s.io/component-base v0.27.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	mvdan.cc/gofumpt v0.4.0 // indirect


### PR DESCRIPTION
xref bestchains/bc-saas#49

After creating a tag like `v0.1.0`, the gorelease action will take about 15 minutes to build the binary and create a draft release (**The draft can only be seen by the administrator**, so that we can add a custom version description, and then make it public for everyone):

![CleanShot 2023-06-25 at 16 08 14](https://github.com/bestchains/bc-cli/assets/5100555/3c2eb8ff-d499-480e-973d-30e50f6909d9)

```bash
$ ./bc-cli version
version: 0.0.2
commit: 16d518d2c4fed6d33ca80efea199f46a6ed9de4c
date: 2023-06-25T07:03:45Z
```