### PR TITLE
chore: use provider to get oauth2 endpoint

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -107,11 +107,8 @@ func newClient(ctx context.Context, config common.AuthConfig) (*client, error) {
 	oauth2Config := oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  config.IssuerURL + "/auth",
-			TokenURL: config.IssuerURL + "/token",
-		},
-		Scopes: []string{"openid", "email", "groups", "profile", "offline_access"},
+		Endpoint:     provider.Endpoint(),
+		Scopes:       []string{"openid", "email", "groups", "profile", "offline_access"},
 	}
 	return &client{
 		httpClient:   httpClient,


### PR DESCRIPTION
As oidc privoder will get the endpoint automatically via `{issuer_url}/.well-known/openid-configuration`,we do not need to specify the auth url and token url manually.
BTW... in a new OIDC environment,we need to enable `http://localhost:26666` as a valid redirect url.